### PR TITLE
Fixed physics bug which caused crash in zoo_physconstraint map

### DIFF
--- a/dlls/physconstraint.cpp
+++ b/dlls/physconstraint.cpp
@@ -143,6 +143,9 @@ void PhysTeleportConstrainedEntity( CBaseEntity *pTeleportSource, IPhysicsObject
 	if ( pFixup->GetMoveType() != MOVETYPE_VPHYSICS )
 		return;
 
+	if ( !pFixup->VPhysicsGetObject() || !pFixup->VPhysicsGetObject()->IsMoveable() )	
+		return;
+
 	QAngle oldAngles = prevAngles;
 
 	if ( !physicsRotate )
@@ -307,6 +310,7 @@ CPhysConstraint::CPhysConstraint( void )
 
 CPhysConstraint::~CPhysConstraint()
 {
+	Deactivate();
 	physenv->DestroyConstraint( m_pConstraint );
 }
 

--- a/game_shared/takedamageinfo.cpp
+++ b/game_shared/takedamageinfo.cpp
@@ -130,7 +130,22 @@ void AddMultiDamage( const CTakeDamageInfo &info, CBaseEntity *pEntity )
 		// setup the damage force & position inside the CTakeDamageInfo (Utility functions for this are in
 		// takedamageinfo.cpp. If you think the damage shouldn't cause force (unlikely!) then you can set the 
 		// damage type to DMG_GENERIC, or | DMG_CRUSH if you need to preserve the damage type for purposes of HUD display.
-		Assert( g_MultiDamage.GetDamageForce() != vec3_origin && g_MultiDamage.GetDamagePosition() != vec3_origin );
+		if ( g_MultiDamage.GetDamageForce() == vec3_origin || g_MultiDamage.GetDamagePosition() == vec3_origin )
+		{
+			static int warningCount = 0;
+			if ( ++warningCount < 10 )
+			{
+				if ( g_MultiDamage.GetDamageForce() == vec3_origin )
+				{
+					Warning( "AddMultiDamage:  g_MultiDamage.GetDamageForce() == vec3_origin\n" );
+				}
+
+				if ( g_MultiDamage.GetDamagePosition() == vec3_origin)
+				{
+					Warning( "AddMultiDamage:  g_MultiDamage.GetDamagePosition() == vec3_origin\n" );
+				}
+			}
+		}
 	}
 }
 

--- a/ivp/ivp_intern/ivp_core.cxx
+++ b/ivp/ivp_intern/ivp_core.cxx
@@ -590,6 +590,23 @@ void IVP_Core::rot_push_core_cs(const IVP_U_Float_Point *rot_impulse_cs)
 // #+# too many calls to this function
 void IVP_Core::commit_all_async_pushes(){   
 
+	// CRITICAL SANITY CHECK: reset speed changes if they somehow became insane
+	// From DmitRex to VXP (bug on zoo_physconvert): This prevents insane speed values to be applied to object.
+	// This code block should not exist, as I seemed to fix most obvious cases where nan's can appear,
+	// but still it may save engine from crashing in some very rare situations
+	if( isnan( this->rot_speed_change.real_length() ) || isnan( this->speed_change.real_length() )
+		|| this->rot_speed_change.real_length() > MAX_PLAUSIBLE_LEN || this->rot_speed_change.real_length() < -MAX_PLAUSIBLE_LEN
+		|| this->speed_change.real_length() > MAX_PLAUSIBLE_LEN || this->speed_change.real_length() < -MAX_PLAUSIBLE_LEN )
+	{
+		IVP_ASSERT(this->rot_speed_change.real_length()<MAX_PLAUSIBLE_LEN);
+		IVP_ASSERT(this->rot_speed_change.real_length()>-MAX_PLAUSIBLE_LEN);
+		IVP_ASSERT(this->speed_change.real_length()<MAX_PLAUSIBLE_LEN);
+		IVP_ASSERT(this->speed_change.real_length()>-MAX_PLAUSIBLE_LEN);
+
+		this->rot_speed_change.set_to_zero();
+		this->speed_change.set_to_zero(); 
+	}
+
     this->rot_speed.add(&this->rot_speed_change);
     this->speed.add(&this->speed_change);
     this->speed_change.set_to_zero(); 

--- a/ivp/ivp_intern/ivp_friction.cxx
+++ b/ivp/ivp_intern/ivp_friction.cxx
@@ -1750,6 +1750,17 @@ void IVP_Mutual_Energizer::destroy_percent_energy(IVP_DOUBLE percent_energy_to_d
 {
     IVP_DOUBLE rot_impulse=calc_impulse_to_reduce_energy_level(rot_speed_potential,inv_rot_inertia[0],inv_rot_inertia[1],percent_energy_to_destroy*rot_energy_potential);
     IVP_DOUBLE trans_impulse=calc_impulse_to_reduce_energy_level(trans_speed_potential,inv_trans_inertia[0],inv_trans_inertia[1],percent_energy_to_destroy*trans_energy_potential);
+
+	// From DmitRex to VXP (bug on zoo_physconvert): HACK!! This happens very rarely, I don't have time to catch it properly, sorry.
+	// I was able to get it only twice, but I don't think it's something serious. `percent_energy_to_destroy` is a problematic value.
+	// Usually happens when player touches physics brush, could be just problem in gamemovement code, because player often stucks in that brush.
+	if( isnan( rot_impulse ) || isnan( trans_impulse ) )
+	{
+		IVP_ASSERT( 0 );
+
+		return;
+	}
+
     if(!core[0]->physical_unmoveable) {
 	core[0]->speed_change.add_multiple(&trans_vec_world,inv_trans_inertia[0]*trans_impulse);
 	core[0]->rot_speed_change.add_multiple(&rot_vec_obj[0],inv_rot_inertia[0]*rot_impulse);

--- a/vphysics/physics_fluid.cpp
+++ b/vphysics/physics_fluid.cpp
@@ -70,6 +70,7 @@ float CPhysicsFluidController::GetDensity()
 	return m_pBuoyancy->m_density;
 }
 
+
 IVP_Template_Buoyancy *CBuoyancyAttacher::get_parameters_per_core( IVP_Core *pCore )
 {
 	if ( pCore )
@@ -86,7 +87,7 @@ IVP_Template_Buoyancy *CBuoyancyAttacher::get_parameters_per_core( IVP_Core *pCo
 		// From DmitRex to VXP (bug on zoo_physconvert): My attempt to solve it without recreating vphysics shadow (read my comments in `void CPhysicsObject::SetVolume( float volume )`
 		// and `bool TransferPhysicsObject( CBaseEntity *pFrom, CBaseEntity *pTo )` ). 
 		if ( pPhys->GetShadowController() || !(pPhys->GetCallbackFlags() & CALLBACK_DO_FLUID_SIMULATION) 
-			// Test attempt to prevent object from floating if it's gravity force bigger than buoyancy force
+			// Don't let buoyancy ratio to become insanely big
 			|| ratio > 1e6 ) // 1e6 is the max possible reasonable value
 		{
 			// NOTE: don't do buoyancy on these guys for now!
@@ -143,7 +144,6 @@ CPhysicsFluidController *CreateFluidController( IVP_Environment *pEnvironment, C
 	// UNDONE: Expose these other parameters
     IVP_Template_Buoyancy buoyancy_input;
     buoyancy_input.medium_density			= ConvertDensityToIVP(pParams->density); // density of water (unit: kg/m^3)
-
     buoyancy_input.pressure_damp_factor     = pParams->damping;
     buoyancy_input.viscosity_factor       = 0.0f;
     buoyancy_input.torque_factor          = 0.01f;

--- a/vphysics/physics_object.cpp
+++ b/vphysics/physics_object.cpp
@@ -502,7 +502,7 @@ void CPhysicsObject::SetVolume( float volume )
 	if ( volume != 0.f )
 	{
 		volume *= HL2IVP_FACTOR*HL2IVP_FACTOR*HL2IVP_FACTOR;
-		float density = GetMass() / m_volume;//volume; // I think using 'volume" is a mistake? Otherwise volume appears to be too small for such big mass. If it breaks water floating physics them revert this change.
+		float density = GetMass() / m_volume;//volume; // I think using 'volume" is a mistake? Otherwise volume appears to be too small for such big mass. If it breaks water floating physics then revert this change.
 		float matDensity;
 		physprops->GetPhysicsProperties( GetMaterialIndexInternal(), &matDensity, NULL, NULL, NULL );
 

--- a/vphysics/physics_object.cpp
+++ b/vphysics/physics_object.cpp
@@ -502,9 +502,14 @@ void CPhysicsObject::SetVolume( float volume )
 	if ( volume != 0.f )
 	{
 		volume *= HL2IVP_FACTOR*HL2IVP_FACTOR*HL2IVP_FACTOR;
-		float density = GetMass() / volume;
+		float density = GetMass() / m_volume;//volume; // I think using 'volume" is a mistake? Otherwise volume appears to be too small for such big mass. If it breaks water floating physics them revert this change.
 		float matDensity;
 		physprops->GetPhysicsProperties( GetMaterialIndexInternal(), &matDensity, NULL, NULL, NULL );
+
+		// From DmitRex to VXP (bug on zoo_physconvert): if you don't want to recreate vphysics shadow for simple_physics_brush 
+		// (read my comment in `bool TransferPhysicsObject( CBaseEntity *pFrom, CBaseEntity *pTo )` - then you can limit m_buoyancyRatio, because it gets too big
+		// (check CShadowController::AttachObject( void ) - game sets Mass of 1e6f which is maximum possible) or use more complex formula.
+		// MAYBE, a fornmula in `IVP_Template_Buoyancy *CBuoyancyAttacher::get_parameters_per_core( IVP_Core *pCore )` can be changed to be more physically accurate.
 		m_buoyancyRatio = density / matDensity;
 	}
 	else


### PR DESCRIPTION
- Fixed physics bug which caused crash in zoo_physconstraint map (see comments in code and my messages in discord);
- Hacky fix for some other rare crash (see comments in ivp_friction.cxx);
- Ported some of phys entities code bits from retail version of Source.